### PR TITLE
make six less restrictive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ geopy==1.11.0
 python-geohash==0.8.5
 flake8==3.0.4
 coverage==4.2
-six==1.10.0
+six>=1.10.0


### PR DESCRIPTION
Adds no upper bound to six so downstream dependencies have more freedom to choose their version

Motivation: Cannot setup pip-tools for DS atm because another library requires six==1.11